### PR TITLE
Fix V3021

### DIFF
--- a/Questor.Modules/ItemCache.cs
+++ b/Questor.Modules/ItemCache.cs
@@ -64,7 +64,7 @@ namespace Questor.Modules
             {
                 if (TypeId == 41) return true;      // Garbage
                 if (TypeId == 42) return true;      // Spiced Wine
-                if (TypeId == 42) return true;      // Antibiotics
+                if (TypeId == 43) return true;      // Antibiotics
                 if (TypeId == 44) return true;      // Enriched Uranium
                 if (TypeId == 45) return true;      // Frozen Plant Seeds
                 if (TypeId == 3673) return true;    // Wheat


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- There are two 'if' statements with identical conditional expressions. The first 'if' statement contains method return. This means that the second 'if' statement is senseless Questor.Modules ItemCache.cs 66